### PR TITLE
Fix build issues: Add slugify function and update React version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "@astrojs/tailwind": "^5.0.0",
     "@tailwindcss/typography": "^0.5.10",
     "astro": "^4.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "tailwindcss": "^3.0.0"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,22 @@ export function formatDate(date) {
 }
 
 /**
+ * Convert a string to a URL-friendly slug
+ * @param {string} text The text to slugify
+ * @returns {string} The slugified text
+ */
+export function slugify(text) {
+  return text
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w-]+/g, '')
+    .replace(/--+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+}
+
+/**
  * Filter out draft content in production
  * @param {Array} posts Array of blog posts
  * @returns {Array} Filtered array of posts


### PR DESCRIPTION
This PR addresses two issues causing the build to fail:

1. Added the missing `slugify` function to `src/utils.js` that is imported in `BlogPostLayout.astro`
2. Updated React and React DOM versions in package.json from 18.0.0 to 19.1.0 to match the versions actually being installed by npm

These changes should resolve the build error:
```
"slugify" is not exported by "src/utils.js", imported by "src/layouts/BlogPostLayout.astro".
```

And fix the warning about React version mismatches:
```
npm warn While resolving: akrem-website@0.0.1
npm warn Found: react@19.1.0
npm warn Could not resolve dependency:
npm warn peer react@"^19.1.0" from react-dom@19.1.0
```