### PR TITLE
Add getRepositoryDetails function for GitHub API integration

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,41 @@ export function slugify(text) {
 }
 
 /**
+ * Fetch repository details from GitHub
+ * @param {string} repoPath Repository path in the format 'username/repo'
+ * @returns {Promise<object>} Repository details
+ */
+export async function getRepositoryDetails(repoPath) {
+  try {
+    // Use fetch API to get repository information from GitHub
+    const [owner, repo] = repoPath.split('/');
+    const response = await fetch(`https://api.github.com/repos/${repoPath}`);
+    
+    if (!response.ok) {
+      console.error(`Error fetching repo ${repoPath}: ${response.statusText}`);
+      return { description: '', gitHubLink: `https://github.com/${repoPath}` };
+    }
+    
+    const data = await response.json();
+    
+    return {
+      description: data.description || '',
+      gitHubLink: data.html_url,
+      stars: data.stargazers_count,
+      forks: data.forks_count,
+      lastUpdate: data.updated_at
+    };
+  } catch (error) {
+    console.error(`Error fetching repository details for ${repoPath}:`, error);
+    // Return basic information even if the fetch fails
+    return { 
+      description: '', 
+      gitHubLink: `https://github.com/${repoPath}`
+    };
+  }
+}
+
+/**
  * Filter out draft content in production
  * @param {Array} posts Array of blog posts
  * @returns {Array} Filtered array of posts


### PR DESCRIPTION
This PR addresses the build error:

```
[ERROR] [vite] x Build failed in 2.51s
src/pages/project/projects.ts (1:9): "getRepositoryDetails" is not exported by "src/utils.js", imported by "src/pages/project/projects.ts".
```

### Changes:

- Added a `getRepositoryDetails` function to `src/utils.js` that fetches repository information from the GitHub API
- The function handles errors gracefully, providing default values if the API request fails
- Returns useful repository information like description, star count, fork count, and last update date

This should resolve the current build error and enable fetching GitHub repository information for your projects page.