### PR TITLE
Fix redirect implementation in projects.astro

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,5 +1,6 @@
 ---
 // This file redirects correctly to the project folder
-import { redirect } from 'astro';
-return redirect('/project/');
+export const prerender = false;
+import { redirect } from 'astro/middleware';
+const response = redirect('/project/');
 ---

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,15 +1,17 @@
 ---
 // This file redirects correctly to the project folder
-export function getStaticPaths() {
-  return [];
-}
-
-export async function get() {
-  return {
-    status: 301,
-    headers: {
-      Location: '/project/'
-    }
-  };
-}
 ---
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0;url=/project/" />
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="/project/">/project/</a>...</p>
+  <script>
+    window.location.href = "/project/";
+  </script>
+</body>
+</html>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,6 +1,15 @@
 ---
 // This file redirects correctly to the project folder
-export const prerender = false;
-import { redirect } from 'astro/middleware';
-const response = redirect('/project/');
+export function getStaticPaths() {
+  return [];
+}
+
+export async function get() {
+  return {
+    status: 301,
+    headers: {
+      Location: '/project/'
+    }
+  };
+}
 ---


### PR DESCRIPTION
This PR addresses the build error:

```
[ERROR] [vite] x Build failed in 2.74s
src/pages/projects.astro (3:9): "redirect" is not exported by "node_modules/astro/dist/@types/astro.js", imported by "src/pages/projects.astro".
```

### Changes:

- Changed the redirect implementation in `projects.astro` to use HTML meta refresh and JavaScript redirect
- Removed the import of the `redirect` function from 'astro' which was causing the build error
- This approach is compatible with Astro 4.0.0 and will work in both static and server-side rendering modes

This HTML-based redirect solution is simple, reliable, and doesn't require any special Astro APIs that might change between versions.