### PR TITLE
Fix redirect implementation in tags.astro

### DIFF
--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -1,4 +1,17 @@
 ---
-import { redirect } from 'astro';
-return redirect('/tag/');
+// This file redirects correctly to the tag folder
 ---
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0;url=/tag/" />
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="/tag/">/tag/</a>...</p>
+  <script>
+    window.location.href = "/tag/";
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR addresses the build error:

```
[ERROR] [vite] x Build failed in 2.32s
src/pages/tags.astro (2:9): "redirect" is not exported by "node_modules/astro/dist/@types/astro.js", imported by "src/pages/tags.astro".
```

### Changes:

- Changed the redirect implementation in `tags.astro` to use HTML meta refresh and JavaScript redirect
- Removed the import of the `redirect` function from 'astro' which was causing the build error
- Applied the same solution that worked for the `projects.astro` file

This HTML-based redirect solution is simple, reliable, and doesn't require any special Astro APIs that might change between versions.