### PR TITLE
Add missing SITE_TAGLINE export to consts.js

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -2,4 +2,5 @@
 // You can import this data from anywhere in your site by using the `import` keyword.
 
 export const SITE_TITLE = 'Akrem Berhanu';
+export const SITE_TAGLINE = 'Technology Consultant & Engineer';
 export const SITE_DESCRIPTION = 'Personal website and portfolio of Akrem Berhanu';


### PR DESCRIPTION
This PR addresses the build error:

```
[ERROR] [vite] x Build failed in 2.40s
src/pages/index.astro (2:21): "SITE_TAGLINE" is not exported by "src/consts.js", imported by "src/pages/index.astro".
```

### Changes:

- Added the missing `SITE_TAGLINE` export to `src/consts.js` with a value of 'Technology Consultant & Engineer'
- This constant is required by the `index.astro` file where it's used in the page title

This fixes another build error that was preventing the site from successfully deploying.